### PR TITLE
Install Inno Setup manually for Windows 2025 latest image

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -49,6 +49,7 @@ jobs:
         run: cd build/windows/x64/runner/Release/ && powershell Compress-Archive -Path * -DestinationPath "MQJ-${{ needs.extract_version.outputs.version }}-windows-x64.zip"
       - name: Run Inno Setup Compiler
         run: |
+          choco install innosetup -y
           "%programfiles(x86)%\Inno Setup 6\iscc.exe" "inno-compiler\inno-build-installer.iss"
         shell: cmd
       - name: Rename installer to include version

--- a/.github/workflows/build-windows-inno.yml
+++ b/.github/workflows/build-windows-inno.yml
@@ -55,9 +55,10 @@ jobs:
           Copy-Item -Path "temp_vcredist\visual-cpp-redistributable-main\*.dll" -Destination "build\windows\x64\runner\Release\" -Force
 
       - name: Run Inno Setup Compiler
-        uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
-        with:
-          path: inno-compiler/inno-build-installer.iss
+        run: |
+          choco install innosetup -y
+          "%programfiles(x86)%\Inno Setup 6\iscc.exe" "inno-compiler\inno-build-installer.iss"
+        shell: cmd
 
       - name: Rename installer to include version
         run: |

--- a/.github/workflows/build-windows-inno.yml
+++ b/.github/workflows/build-windows-inno.yml
@@ -31,7 +31,7 @@ jobs:
   build_windows:
     name: 🪟 Build Windows App
     needs: extract_version
-    runs-on: windows-2025
+    runs-on: windows-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-windows-inno.yml
+++ b/.github/workflows/build-windows-inno.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'App version override (leave empty to extract from pubspec.yaml)'
+        description: "App version override (leave empty to extract from pubspec.yaml)"
         required: false
-        default: ''
+        default: ""
 
 jobs:
   extract_version:
@@ -31,7 +31,7 @@ jobs:
   build_windows:
     name: 🪟 Build Windows App
     needs: extract_version
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -55,9 +55,10 @@ jobs:
           Copy-Item -Path "temp_vcredist\visual-cpp-redistributable-main\*.dll" -Destination "build\windows\x64\runner\Release\" -Force
 
       - name: Run Inno Setup Compiler
-        run: |
-          "%programfiles(x86)%\Inno Setup 6\iscc.exe" "inno-compiler\inno-build-installer.iss"
-        shell: cmd
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
+        with:
+          path: inno-compiler/inno-build-installer.iss
+
       - name: Rename installer to include version
         run: |
           Move-Item -Path "build\installer\app-windows-installer.exe" -Destination "MQJ-${{ needs.extract_version.outputs.version }}-windows-64-installer.exe" -Force
@@ -67,5 +68,3 @@ jobs:
         with:
           name: MQJ-${{ needs.extract_version.outputs.version }}-windows-installer
           path: MQJ-${{ needs.extract_version.outputs.version }}-windows-64-installer.exe
-
-  


### PR DESCRIPTION
This pull request updates the Windows build workflow.

* Added a step to install Inno Setup using Chocolatey (`choco install innosetup -y`) before running the installer compiler, ensuring the required tool is available in the build environment.
