### PR TITLE
Set to latest stable Flutter version when building for Linux ARM

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -106,7 +106,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: master
-          flutter-version: 3.35.6 # pin to current stable version
+          flutter-version: 3.44.0 # pin to current stable version
           cache: true
       - run: sudo apt-get update -y
       - run: sudo apt-get install -y ninja-build libgtk-3-dev

--- a/.github/workflows/build-linux-arm.yml
+++ b/.github/workflows/build-linux-arm.yml
@@ -19,7 +19,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: master
-          flutter-version: 3.41.7
+          flutter-version: 3.44.0
           cache: true
 
       - run: sudo apt-get update -y


### PR DESCRIPTION
This PR updates the Flutter version in workflow files for jobs that building artifact for Linux ARM.

This solves issue like this

<img width="1195" height="180" alt="Screenshot 2026-05-19 at 9 31 44 PM" src="https://github.com/user-attachments/assets/52c426ab-279c-43f7-9423-1038b31d06a1" />

